### PR TITLE
Add optional merge process log via --print-chunks flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,6 @@ SCENARIOS=$(shell ls bin/tests/scenarios)
 LANGUAGE=java
 SUFFIX=.java
 LOG_LEVEL=debug
-DIR=bin/tests/scenarios/abstract
 
 run_merge_on_dir:
 	cargo run -- merge --left-path=$(DIR)/left$(SUFFIX) --base-path=$(DIR)/base$(SUFFIX) --right-path=$(DIR)/right$(SUFFIX) --merge-path=$(DIR)/merge.output$(SUFFIX) --log-level=$(LOG_LEVEL) --language=$(LANGUAGE)

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ SCENARIOS=$(shell ls bin/tests/scenarios)
 LANGUAGE=java
 SUFFIX=.java
 LOG_LEVEL=debug
+DIR=bin/tests/scenarios/abstract
 
 run_merge_on_dir:
 	cargo run -- merge --left-path=$(DIR)/left$(SUFFIX) --base-path=$(DIR)/base$(SUFFIX) --right-path=$(DIR)/right$(SUFFIX) --merge-path=$(DIR)/merge.output$(SUFFIX) --log-level=$(LOG_LEVEL) --language=$(LANGUAGE)

--- a/bin/src/cli_args.rs
+++ b/bin/src/cli_args.rs
@@ -57,4 +57,8 @@ pub struct MergeCliArgs {
     /// If not provided the language will try to be inferred by the extension.
     #[arg(long)]
     pub(crate) language: Option<String>,
+
+    /// Prints a detailed log of the merge process in the CST nodes
+    #[arg(long)]
+    pub print_chunks: bool,
 }

--- a/bin/src/control.rs
+++ b/bin/src/control.rs
@@ -48,6 +48,7 @@ pub fn run_tool_on_merge_scenario(
     base: &str,
     left: &str,
     right: &str,
+    print_chunks: bool,
 ) -> Result<ExecutionResult, ExecutionError> {
     if base == left {
         log::info!("Early returning because base equals left");
@@ -112,6 +113,7 @@ pub fn run_tool_on_merge_scenario(
         &matchings_left_base,
         &matchings_right_base,
         &matchings_left_right,
+        print_chunks,
     )
     .map_err(ExecutionError::MergeError)?;
     log::info!("Finished merge of the trees in {:?}", start.elapsed());

--- a/bin/src/main.rs
+++ b/bin/src/main.rs
@@ -42,7 +42,7 @@ fn run_merge(args: MergeCliArgs) {
         std::process::exit(cli_exit_codes::INVALID_LANGUAGE_ERROR)
     });
 
-    let result = control::run_tool_on_merge_scenario(language, &base, &left, &right)
+    let result = control::run_tool_on_merge_scenario(language, &base, &left, &right, args.print_chunks)
         .unwrap_or_else(|error| {
             log::error!("Error while running tool: {}", error);
             std::process::exit(cli_exit_codes::INTERNAL_EXECUTION_ERROR)

--- a/bin/tests/scenarios.rs
+++ b/bin/tests/scenarios.rs
@@ -8,7 +8,7 @@ fn all_java_samples_work_correctly() -> Result<(), Box<dyn std::error::Error>> {
         let right = std::fs::read_to_string(format!("{}/right.java", sample_path.display()))?;
 
         let expected = std::fs::read_to_string(format!("{}/merge.java", sample_path.display()))?;
-        let result = bin::run_tool_on_merge_scenario(model::Language::Java, &base, &left, &right)
+        let result = bin::run_tool_on_merge_scenario(model::Language::Java, &base, &left, &right, false)
             .map_err(|err| format!("Failed on {} with error: {}", sample_path.display(), err));
 
         assert_eq!(

--- a/merge/src/merge.rs
+++ b/merge/src/merge.rs
@@ -14,6 +14,7 @@ pub fn merge<'a>(
     base_left_matchings: &'a Matchings<'a>,
     base_right_matchings: &'a Matchings<'a>,
     left_right_matchings: &'a Matchings<'a>,
+    print_chunks: bool,
 ) -> Result<MergedCSTNode<'a>, MergeError> {
     if left.kind() != right.kind() {
         log::debug!(
@@ -39,6 +40,7 @@ pub fn merge<'a>(
                     base_left_matchings,
                     base_right_matchings,
                     left_right_matchings,
+                    print_chunks,
                 )?)
             } else {
                 Ok(ordered_merge(
@@ -47,6 +49,7 @@ pub fn merge<'a>(
                     base_left_matchings,
                     base_right_matchings,
                     left_right_matchings,
+                    print_chunks,
                 )?)
             }
         }
@@ -103,6 +106,7 @@ mod tests {
             &Matchings::empty(),
             &Matchings::empty(),
             &Matchings::empty(),
+            false,
         )
         .unwrap_err();
 

--- a/merge/src/ordered_merge.rs
+++ b/merge/src/ordered_merge.rs
@@ -28,6 +28,7 @@ pub fn ordered_merge<'a>(
     base_left_matchings: &'a Matchings<'a>,
     base_right_matchings: &'a Matchings<'a>,
     left_right_matchings: &'a Matchings<'a>,
+    print_chunks: bool,
 ) -> Result<MergedCSTNode<'a>, MergeError> {
     // Nodes of different kind, early return
     if left.kind != right.kind {
@@ -67,12 +68,14 @@ pub fn ordered_merge<'a>(
         ) {
             (true, Some(_), Some(matching_base_left), Some(_), Some(_)) => {
                 
-                if !current_unstable.is_empty(){
-                    log.push(MergeChunk::Unstable(std::mem::take(&mut current_unstable)));
+                if print_chunks {
+                    if !current_unstable.is_empty(){
+                        log.push(MergeChunk::Unstable(std::mem::take(&mut current_unstable)));
+                    }
+                    current_stable.left_nodes.push(cur_left);
+                    current_stable.base_nodes.push(matching_base_left.matching_node);
+                    current_stable.right_nodes.push(cur_right);
                 }
-                current_stable.left_nodes.push(cur_left);
-                current_stable.base_nodes.push(matching_base_left.matching_node);
-                current_stable.right_nodes.push(cur_right);
                 
                 result_children.push(crate::merge(
                     matching_base_left.matching_node,
@@ -81,6 +84,7 @@ pub fn ordered_merge<'a>(
                     base_left_matchings,
                     base_right_matchings,
                     left_right_matchings,
+                    print_chunks,
                 )?);
 
                 cur_left_option = children_left_it.next();
@@ -88,11 +92,13 @@ pub fn ordered_merge<'a>(
             }
             (true, Some(_), None, Some(_), None) => {
 
-                if !current_unstable.is_empty() {
-                    log.push(MergeChunk::Unstable(std::mem::take(&mut current_unstable)));
+                if print_chunks {
+                    if !current_unstable.is_empty() {
+                        log.push(MergeChunk::Unstable(std::mem::take(&mut current_unstable)));
+                    }
+                    current_stable.left_nodes.push(cur_left);
+                    current_stable.right_nodes.push(cur_right);
                 }
-                current_stable.left_nodes.push(cur_left);
-                current_stable.right_nodes.push(cur_right);
 
                 result_children.push(crate::merge(
                     cur_left,
@@ -101,6 +107,7 @@ pub fn ordered_merge<'a>(
                     base_left_matchings,
                     base_right_matchings,
                     left_right_matchings,
+                    print_chunks,
                 )?);
 
                 cur_left_option = children_left_it.next();
@@ -108,12 +115,14 @@ pub fn ordered_merge<'a>(
             }
             (true, Some(_), Some(matching_base_left), Some(_), None) => {
 
-                if !current_unstable.is_empty() {
-                    log.push(MergeChunk::Unstable(std::mem::take(&mut current_unstable)));
+                if print_chunks {
+                    if !current_unstable.is_empty() {
+                        log.push(MergeChunk::Unstable(std::mem::take(&mut current_unstable)));
+                    }
+                    current_stable.left_nodes.push(cur_left);
+                    current_stable.base_nodes.push(matching_base_left.matching_node);
+                    current_stable.right_nodes.push(cur_right);
                 }
-                current_stable.left_nodes.push(cur_left);
-                current_stable.base_nodes.push(matching_base_left.matching_node);
-                current_stable.right_nodes.push(cur_right);
 
                 result_children.push(crate::merge(
                     matching_base_left.matching_node,
@@ -122,6 +131,7 @@ pub fn ordered_merge<'a>(
                     base_left_matchings,
                     base_right_matchings,
                     left_right_matchings,
+                    print_chunks,
                 )?);
 
                 cur_left_option = children_left_it.next();
@@ -129,12 +139,14 @@ pub fn ordered_merge<'a>(
             }
             (true, Some(_), None, Some(_), Some(matching_base_right)) => {
 
-                if !current_unstable.is_empty() {
-                    log.push(MergeChunk::Unstable(std::mem::take(&mut current_unstable)));
+                if print_chunks {
+                    if !current_unstable.is_empty() {
+                        log.push(MergeChunk::Unstable(std::mem::take(&mut current_unstable)));
+                    }
+                    current_stable.left_nodes.push(cur_left);
+                    current_stable.base_nodes.push(matching_base_right.matching_node);
+                    current_stable.right_nodes.push(cur_right);
                 }
-                current_stable.left_nodes.push(cur_left);
-                current_stable.base_nodes.push(matching_base_right.matching_node);
-                current_stable.right_nodes.push(cur_right);
 
                 result_children.push(crate::merge(
                     matching_base_right.matching_node,
@@ -143,17 +155,20 @@ pub fn ordered_merge<'a>(
                     base_left_matchings,
                     base_right_matchings,
                     left_right_matchings,
+                    print_chunks,
                 )?);
 
                 cur_left_option = children_left_it.next();
                 cur_right_option = children_right_it.next();
             }
             (false, Some(_), Some(_), None, Some(matching_base_right)) => {
-                if !current_stable.is_empty() { 
-                    log.push(MergeChunk::Stable(std::mem::take(&mut current_stable))); 
-                }
 
-                current_unstable.right_nodes.push(cur_right);
+                if print_chunks {
+                    if !current_stable.is_empty() { 
+                        log.push(MergeChunk::Stable(std::mem::take(&mut current_stable))); 
+                    }
+                    current_unstable.right_nodes.push(cur_right);
+                }
 
                 if !matching_base_right.is_perfect_match {
                     result_children.push(MergedCSTNode::Conflict {
@@ -166,10 +181,12 @@ pub fn ordered_merge<'a>(
             }
             (false, Some(_), Some(_), None, None) => {
 
-                if !current_stable.is_empty() { 
-                    log.push(MergeChunk::Stable(std::mem::take(&mut current_stable)));
+                if print_chunks {
+                    if !current_stable.is_empty() { 
+                        log.push(MergeChunk::Stable(std::mem::take(&mut current_stable)));
+                    }
+                    current_unstable.right_nodes.push(cur_right);
                 }
-                current_unstable.right_nodes.push(cur_right);
 
                 result_children.push(cur_right.into());
 
@@ -177,10 +194,12 @@ pub fn ordered_merge<'a>(
             }
             (false, Some(_), None, None, Some(matching_base_right)) => {
 
-                if !current_stable.is_empty() {
-                    log.push(MergeChunk::Stable(std::mem::take(&mut current_stable)));
+                if print_chunks {
+                    if !current_stable.is_empty() {
+                        log.push(MergeChunk::Stable(std::mem::take(&mut current_stable)));
+                    }
+                    current_unstable.right_nodes.push(cur_right);
                 }
-                current_unstable.right_nodes.push(cur_right);
 
                 if !matching_base_right.is_perfect_match {
                     result_children.push(MergedCSTNode::Conflict {
@@ -192,20 +211,24 @@ pub fn ordered_merge<'a>(
             }
             (false, Some(_), None, None, None) => {
 
-                if !current_stable.is_empty() {
-                    log.push(MergeChunk::Stable(std::mem::take(&mut current_stable)));
+                if print_chunks {
+                    if !current_stable.is_empty() {
+                        log.push(MergeChunk::Stable(std::mem::take(&mut current_stable)));
+                    }
+                    current_unstable.right_nodes.push(cur_right);
                 }
-                current_unstable.right_nodes.push(cur_right);
 
                 result_children.push(cur_right.into());
                 cur_right_option = children_right_it.next();
             }
             (false, None, Some(matching_base_left), Some(_), Some(_)) => {
 
-                if !current_stable.is_empty() {
-                    log.push(MergeChunk::Stable(std::mem::take(&mut current_stable)));
+                if print_chunks {
+                    if !current_stable.is_empty() {
+                        log.push(MergeChunk::Stable(std::mem::take(&mut current_stable)));
+                    }
+                    current_unstable.left_nodes.push(cur_left);
                 }
-                current_unstable.left_nodes.push(cur_left);
 
                 if !matching_base_left.is_perfect_match {
                     result_children.push(MergedCSTNode::Conflict {
@@ -218,10 +241,12 @@ pub fn ordered_merge<'a>(
             }
             (false, None, Some(matching_base_left), Some(_), None) => {
 
-                if !current_stable.is_empty() {
-                    log.push(MergeChunk::Stable(std::mem::take(&mut current_stable)));
+                if print_chunks {
+                    if !current_stable.is_empty() {
+                        log.push(MergeChunk::Stable(std::mem::take(&mut current_stable)));
+                    }
+                    current_unstable.left_nodes.push(cur_left);
                 }
-                current_unstable.left_nodes.push(cur_left);
 
                 if !matching_base_left.is_perfect_match {
                     result_children.push(MergedCSTNode::Conflict {
@@ -233,12 +258,14 @@ pub fn ordered_merge<'a>(
             }
             (false, None, Some(matching_base_left), None, Some(matching_base_right)) => {
                 
-                if !current_stable.is_empty() {
-                    log.push(MergeChunk::Stable(std::mem::take(&mut current_stable)));
+                if print_chunks {
+                    if !current_stable.is_empty() {
+                        log.push(MergeChunk::Stable(std::mem::take(&mut current_stable)));
+                    }
+                    current_unstable.left_nodes.push(cur_left);
+                    current_unstable.right_nodes.push(cur_right);
+                    current_unstable.base_nodes.push(matching_base_left.matching_node);
                 }
-                current_unstable.left_nodes.push(cur_left);
-                current_unstable.right_nodes.push(cur_right);
-                current_unstable.base_nodes.push(matching_base_left.matching_node);
 
                 
                 match (
@@ -271,10 +298,12 @@ pub fn ordered_merge<'a>(
             }
             (false, None, Some(matching_base_left), None, None) => {
 
-                if !current_stable.is_empty() {
-                    log.push(MergeChunk::Stable(std::mem::take(&mut current_stable)));
+                if print_chunks {
+                    if !current_stable.is_empty() {
+                        log.push(MergeChunk::Stable(std::mem::take(&mut current_stable)));
+                    }
+                    current_unstable.left_nodes.push(cur_left);
                 }
-                current_unstable.left_nodes.push(cur_left);
 
                 if !matching_base_left.is_perfect_match {
                     result_children.push(MergedCSTNode::Conflict {
@@ -290,31 +319,37 @@ pub fn ordered_merge<'a>(
             }
             (false, None, None, Some(_), Some(_)) => {
 
-                if !current_stable.is_empty() {
-                    log.push(MergeChunk::Stable(std::mem::take(&mut current_stable)));
+                if print_chunks{
+                    if !current_stable.is_empty() {
+                        log.push(MergeChunk::Stable(std::mem::take(&mut current_stable)));
+                    }
+                    current_unstable.left_nodes.push(cur_left);
                 }
-                current_unstable.left_nodes.push(cur_left);
 
                 result_children.push(cur_left.into());
                 cur_left_option = children_left_it.next();
             }
             (false, None, None, Some(_), None) => {
 
-                if !current_stable.is_empty() {
-                    log.push(MergeChunk::Stable(std::mem::take(&mut current_stable)));
+                if print_chunks {
+                    if !current_stable.is_empty() {
+                        log.push(MergeChunk::Stable(std::mem::take(&mut current_stable)));
+                    }
+                    current_unstable.left_nodes.push(cur_left);
                 }
-                current_unstable.left_nodes.push(cur_left);
 
                 result_children.push(cur_left.into());
                 cur_left_option = children_left_it.next();
             }
             (false, None, None, None, Some(matching_base_right)) => {
 
-                if !current_stable.is_empty() {
-                    log.push(MergeChunk::Stable(std::mem::take(&mut current_stable)));
+                if print_chunks {
+                    if !current_stable.is_empty() {
+                        log.push(MergeChunk::Stable(std::mem::take(&mut current_stable)));
+                    }
+                    current_unstable.left_nodes.push(cur_left);
+                    current_unstable.right_nodes.push(cur_right);
                 }
-                current_unstable.left_nodes.push(cur_left);
-                current_unstable.right_nodes.push(cur_right);
 
                 if !matching_base_right.is_perfect_match {
                     result_children.push(MergedCSTNode::Conflict {
@@ -330,11 +365,13 @@ pub fn ordered_merge<'a>(
             }
             (false, None, None, None, None) => {
 
-                if !current_stable.is_empty() {
-                    log.push(MergeChunk::Stable(std::mem::take(&mut current_stable)));
+                if print_chunks{
+                    if !current_stable.is_empty() {
+                        log.push(MergeChunk::Stable(std::mem::take(&mut current_stable)));
+                    }
+                    current_unstable.left_nodes.push(cur_left);
+                    current_unstable.right_nodes.push(cur_right);
                 }
-                current_unstable.left_nodes.push(cur_left);
-                current_unstable.right_nodes.push(cur_right);
 
                 result_children.push(MergedCSTNode::Conflict {
                     left: Some(Box::new(cur_left.into())),
@@ -379,8 +416,10 @@ pub fn ordered_merge<'a>(
         }
     }
 
-    if !current_stable.is_empty() {
-        log.push(MergeChunk::Stable(std::mem::take(&mut current_stable)));
+    if print_chunks {
+        if !current_stable.is_empty() {
+            log.push(MergeChunk::Stable(std::mem::take(&mut current_stable)));
+        }
     }
 
     while let Some(cur_left) = cur_left_option {
@@ -393,80 +432,82 @@ pub fn ordered_merge<'a>(
         cur_right_option = children_right_it.next();
     }
 
-    if !current_unstable.is_empty() { 
-        log.push(MergeChunk::Unstable(std::mem::take(&mut current_unstable))); 
-    }
-
-    println!("\n--- ORDERED CHUNK LOG ---");
-    println!("===========================================================");
-
-    // Helper para formatar a lista de nós de forma completa
-    let format_node_list = |nodes: &Vec<&model::CSTNode>| -> String {
-        if nodes.is_empty() {
-            return "-".to_string();
+    if print_chunks {
+        if !current_unstable.is_empty() { 
+            log.push(MergeChunk::Unstable(std::mem::take(&mut current_unstable))); 
         }
 
-        let first_node = nodes.first().unwrap();
-        let last_node = nodes.last().unwrap();
-        
-        let start_line = first_node.start_position().row + 1;
-        let end_line = last_node.end_position().row + 1;
-        
-        let range = if start_line == end_line {
-            format!("(L{})", start_line)
-        } else {
-            format!("(L{}-L{})", start_line, end_line)
+        println!("\n--- ORDERED CHUNK LOG ---");
+        println!("===========================================================");
+
+        // Helper para formatar a lista de nós de forma completa
+        let format_node_list = |nodes: &Vec<&model::CSTNode>| -> String {
+            if nodes.is_empty() {
+                return "-".to_string();
+            }
+
+            let first_node = nodes.first().unwrap();
+            let last_node = nodes.last().unwrap();
+            
+            let start_line = first_node.start_position().row + 1;
+            let end_line = last_node.end_position().row + 1;
+            
+            let range = if start_line == end_line {
+                format!("(L{})", start_line)
+            } else {
+                format!("(L{}-L{})", start_line, end_line)
+            };
+            
+            const MAX_NODES_TO_SHOW: usize = 3;
+            const MAX_CONTENT_LEN: usize = 20;
+
+            // Itera para criar a descrição detalhada de cada nó
+            let descriptions: Vec<String> = nodes.iter().map(|n| {
+                // Limpa e trunca o conteúdo para legibilidade
+                let mut content = n.contents().replace(['\n', '\r'], " ").trim().to_string();
+                if content.len() > MAX_CONTENT_LEN {
+                    content.truncate(MAX_CONTENT_LEN - 3);
+                    content.push_str("...");
+                }
+                format!("{}: '{}'", n.kind(), content)
+            }).take(MAX_NODES_TO_SHOW).collect();
+
+            let mut summary = format!("[{}]", descriptions.join(", "));
+            if nodes.len() > MAX_NODES_TO_SHOW {
+                summary.push_str("...");
+            }
+            
+            format!("{} nós {} {}", nodes.len(), range, summary)
         };
-        
-        const MAX_NODES_TO_SHOW: usize = 3;
-        const MAX_CONTENT_LEN: usize = 20;
 
-        // Itera para criar a descrição detalhada de cada nó
-        let descriptions: Vec<String> = nodes.iter().map(|n| {
-            // Limpa e trunca o conteúdo para legibilidade
-            let mut content = n.contents().replace(['\n', '\r'], " ").trim().to_string();
-            if content.len() > MAX_CONTENT_LEN {
-                content.truncate(MAX_CONTENT_LEN - 3);
-                content.push_str("...");
+        for (i, chunk) in log.iter().enumerate() {
+            match chunk {
+                MergeChunk::Stable(data) => {
+                    println!("-- stable chunk #{} --", i + 1);
+                    let l_info = format_node_list(&data.left_nodes);
+                    let b_info = format_node_list(&data.base_nodes);
+                    let r_info = format_node_list(&data.right_nodes);
+                    
+                    // Aumentamos a largura da coluna para acomodar o texto extra
+                    println!("    Left (L):  {:<85}", l_info);
+                    println!("    Base (B):  {:<85}", b_info);
+                    println!("    Right (R): {}", r_info);
+                }
+                MergeChunk::Unstable(data) => {
+                    println!("-- unstable chunk #{} --", i + 1);
+                    let l_info = format_node_list(&data.left_nodes);
+                    let b_info = format_node_list(&data.base_nodes);
+                    let r_info = format_node_list(&data.right_nodes);
+
+                    println!("    Left (L):  {:<85}", l_info);
+                    println!("    Base (B):  {:<85}", b_info);
+                    println!("    Right (R): {}", r_info);
+                }
             }
-            format!("{}: '{}'", n.kind(), content)
-        }).take(MAX_NODES_TO_SHOW).collect();
-
-        let mut summary = format!("[{}]", descriptions.join(", "));
-        if nodes.len() > MAX_NODES_TO_SHOW {
-            summary.push_str("...");
+            println!("-----------------------------------------------------------"); 
         }
-        
-        format!("{} nós {} {}", nodes.len(), range, summary)
-    };
-
-    for (i, chunk) in log.iter().enumerate() {
-        match chunk {
-            MergeChunk::Stable(data) => {
-                println!("-- stable chunk #{} --", i + 1);
-                let l_info = format_node_list(&data.left_nodes);
-                let b_info = format_node_list(&data.base_nodes);
-                let r_info = format_node_list(&data.right_nodes);
-                
-                // Aumentamos a largura da coluna para acomodar o texto extra
-                println!("    Left (L):  {:<85}", l_info);
-                println!("    Base (B):  {:<85}", b_info);
-                println!("    Right (R): {}", r_info);
-            }
-            MergeChunk::Unstable(data) => {
-                println!("-- unstable chunk #{} --", i + 1);
-                let l_info = format_node_list(&data.left_nodes);
-                let b_info = format_node_list(&data.base_nodes);
-                let r_info = format_node_list(&data.right_nodes);
-
-                println!("    Left (L):  {:<85}", l_info);
-                println!("    Base (B):  {:<85}", b_info);
-                println!("    Right (R): {}", r_info);
-            }
-        }
-        println!("-----------------------------------------------------------"); 
+        println!("--- END ORDERED CHUNK LOG ---\n");
     }
-    println!("--- END ORDERED CHUNK LOG ---\n");
 
     Ok(MergedCSTNode::NonTerminal {
         kind: left.kind,
@@ -501,6 +542,7 @@ mod tests {
             &matchings_base_parent_a,
             &matchings_base_parent_b,
             &matchings_parents,
+            false,
         )?;
         let merged_tree_swap = ordered_merge(
             parent_b.try_into().unwrap(),
@@ -508,6 +550,7 @@ mod tests {
             &matchings_base_parent_b,
             &matchings_base_parent_a,
             &matchings_parents,
+            false,
         )?;
 
         assert_eq!(expected_merge, &merged_tree);
@@ -532,6 +575,7 @@ mod tests {
             &matchings_base_parent_a,
             &matchings_base_parent_b,
             &matchings_parents,
+            false
         )?;
 
         assert_eq!(expected_merge, &merged_tree);
@@ -928,6 +972,7 @@ mod tests {
             &matchings_base_parent_a,
             &matchings_base_parent_b,
             &matchings_parents,
+            false,
         )?;
         let merged_tree_swap = ordered_merge(
             (&parent_b).try_into().unwrap(),
@@ -935,6 +980,7 @@ mod tests {
             &matchings_base_parent_b,
             &matchings_base_parent_a,
             &matchings_parents,
+            false,
         )?;
 
         assert_eq!(
@@ -1919,7 +1965,7 @@ mod tests {
         };
 
         let matchings = Matchings::empty();
-        let result = ordered_merge(&kind_a, &kind_b, &matchings, &matchings, &matchings);
+        let result = ordered_merge(&kind_a, &kind_b, &matchings, &matchings, &matchings, false);
 
         assert!(result.is_err());
         assert_eq!(


### PR DESCRIPTION
- Adds a `--print-chunks` boolean flag to the `merge` command.
- Modifies `ordered_merge` to produce a sequential log of stable and unstable node chunks based on tree nodes.
- Modifies `unordered_merge` to produce a summary of actions (merged, added, conflicts) for non-ordered structures.
- The log output is disabled by default and only activates when the flag is present.